### PR TITLE
Move javascript out of AJAXed parts.

### DIFF
--- a/app/views/usergroups/index.html.erb
+++ b/app/views/usergroups/index.html.erb
@@ -1,3 +1,4 @@
+<%= javascript 'lookup_keys', 'usergroups' %>
 <% title _("User Groups") %>
 
 <% title_actions display_link_if_authorized(_("New User group"), hash_for_new_usergroup_path) %>


### PR DESCRIPTION
Ivan N. pointed out that for AJAX-loaded parts, the Javascript content might not get through / get correctly used.

For me, clicking on the green "Add external user group" did not open the form.
