### PR TITLE
Fixes #8426 - Move scoped search into concerns

### DIFF
--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -3,6 +3,7 @@ class Architecture < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name
   include Parameterizable::ByIdName
+  include SearchScope::Architecture
 
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
   validates_lengths_from_database
@@ -13,8 +14,4 @@ class Architecture < ActiveRecord::Base
   has_and_belongs_to_many :operatingsystems
   validates :name, :presence => true, :uniqueness => true, :no_whitespace => true
   audited :allow_mass_assignment => true
-
-  scoped_search :on => :name, :complete_value => :true
-  scoped_search :on => :hosts_count
-
 end

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -4,6 +4,7 @@ class ComputeResource < ActiveRecord::Base
   include Encryptable
   include Authorizable
   include Parameterizable::ByIdName
+  include SearchScope::ComputeResource
   encrypts :password
 
   class_attribute :supported_providers
@@ -28,9 +29,7 @@ class ComputeResource < ActiveRecord::Base
   validate :ensure_provider_not_changed, :on => :update
   validates :provider, :presence => true, :inclusion => { :in => proc { self.providers } }
   validates :url, :presence => true
-  scoped_search :on => :name, :complete_value => :true
-  scoped_search :on => :type, :complete_value => :true
-  scoped_search :on => :id, :complete_value => :true
+
   before_save :sanitize_url
   has_many_hosts
   has_many :images, :dependent => :destroy

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -3,6 +3,9 @@ module AuditExtensions
   extend ActiveSupport::Concern
 
   included do
+    include Authorizable
+    include SearchScope::Audit
+
     belongs_to :users, :class_name => 'User'
     belongs_to :search_users, :class_name => 'User', :foreign_key => :user_id
     belongs_to :search_hosts, :class_name => 'Host', :foreign_key => :auditable_id
@@ -12,26 +15,8 @@ module AuditExtensions
     belongs_to :search_os, :class_name => 'Operatingsystem', :foreign_key => :auditable_id
     belongs_to :search_class, :class_name => 'Puppetclass', :foreign_key => :auditable_id
 
-    scoped_search :on => [:username, :remote_address], :complete_value => true
-    scoped_search :on => :audited_changes, :rename => 'changes'
-    scoped_search :on => :created_at, :complete_value => true, :rename => :time, :default_order => :desc
-    scoped_search :on => :action, :complete_value => { :create => 'create', :update => 'update', :delete => 'destroy' }
-    scoped_search :on => :auditable_type, :complete_value => { :host => 'Host', :parameter => 'Parameter', :architecture => 'Architecture',
-                                                               :puppetclass => 'Puppetclass', :os => 'Operatingsystem', :hostgroup => 'Hostgroup',
-                                                               :template => "ConfigTemplate" }, :rename => :type
-
-    scoped_search :in => :search_parameters, :on => :name, :complete_value => true, :rename => :parameter, :only_explicit => true
-    scoped_search :in => :search_templates, :on => :name, :complete_value => true, :rename => :template, :only_explicit => true
-    scoped_search :in => :search_os, :on => :name, :complete_value => true, :rename => :os, :only_explicit => true
-    scoped_search :in => :search_class, :on => :name, :complete_value => true, :rename => :puppetclass, :only_explicit => true
-    scoped_search :in => :search_hosts, :on => :name, :complete_value => true, :rename => :host, :only_explicit => true
-    scoped_search :in => :search_hostgroups, :on => :name, :complete_value => true, :rename => :hostgroup, :only_explicit => true
-    scoped_search :in => :search_users, :on => :login, :complete_value => true, :rename => :user, :only_explicit => true
-
     before_save :ensure_username, :ensure_audtiable_and_associated_name
     after_validation :fix_auditable_type
-
-    include Authorizable
   end
 
   private

--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -2,6 +2,8 @@ module NestedAncestryCommon
   extend ActiveSupport::Concern
 
   included do
+    include SearchScope::NestedAncestry
+
     audited :except => [:title], :allow_mass_assignment => true
     has_associated_audits
     has_ancestry :orphan_strategy => :restrict
@@ -13,9 +15,6 @@ module NestedAncestryCommon
     validates :name, :presence => true, :uniqueness => {:scope => :ancestry, :case_sensitive => false}
     validates :title, :presence => true, :uniqueness => true
     validate :title_and_lookup_key_length
-
-    scoped_search :on => :title, :complete_value => true, :default_order => true
-    scoped_search :on => :name, :complete_value => :true
 
     # attribute used by *_names and *_name methods.  default is :name
     attr_name :title

--- a/app/models/concerns/search_scope.rb
+++ b/app/models/concerns/search_scope.rb
@@ -1,0 +1,2 @@
+module SearchScope
+end

--- a/app/models/concerns/search_scope/architecture.rb
+++ b/app/models/concerns/search_scope/architecture.rb
@@ -1,0 +1,10 @@
+module SearchScope
+  module Architecture
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => :true
+      scoped_search :on => :hosts_count
+    end
+  end
+end

--- a/app/models/concerns/search_scope/audit.rb
+++ b/app/models/concerns/search_scope/audit.rb
@@ -1,0 +1,24 @@
+module SearchScope
+  module Audit
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => [:username, :remote_address], :complete_value => true
+      scoped_search :on => :audited_changes, :rename => 'changes'
+      scoped_search :on => :created_at, :complete_value => true, :rename => :time, :default_order => :desc
+      scoped_search :on => :action, :complete_value => { :create => 'create', :update => 'update', :delete => 'destroy' }
+      scoped_search :on => :auditable_type, :complete_value => { :host => 'Host', :parameter => 'Parameter', :architecture => 'Architecture',
+                                                                 :puppetclass => 'Puppetclass', :os => 'Operatingsystem', :hostgroup => 'Hostgroup',
+                                                                 :template => "ConfigTemplate" }, :rename => :type
+
+      scoped_search :in => :search_parameters, :on => :name, :complete_value => true, :rename => :parameter, :only_explicit => true
+      scoped_search :in => :search_templates, :on => :name, :complete_value => true, :rename => :template, :only_explicit => true
+      scoped_search :in => :search_os, :on => :name, :complete_value => true, :rename => :os, :only_explicit => true
+      scoped_search :in => :search_class, :on => :name, :complete_value => true, :rename => :puppetclass, :only_explicit => true
+      scoped_search :in => :search_hosts, :on => :name, :complete_value => true, :rename => :host, :only_explicit => true
+      scoped_search :in => :search_hostgroups, :on => :name, :complete_value => true, :rename => :hostgroup, :only_explicit => true
+      scoped_search :in => :search_users, :on => :login, :complete_value => true, :rename => :user, :only_explicit => true
+    end
+  end
+end
+

--- a/app/models/concerns/search_scope/common_parameter.rb
+++ b/app/models/concerns/search_scope/common_parameter.rb
@@ -1,0 +1,10 @@
+module SearchScope
+  module CommonParameter
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => :true
+      scoped_search :on => :value, :complete_value => :true
+    end
+  end
+end

--- a/app/models/concerns/search_scope/compute_resource.rb
+++ b/app/models/concerns/search_scope/compute_resource.rb
@@ -1,0 +1,12 @@
+module SearchScope
+  module ComputeResource
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => :true
+      scoped_search :on => :type, :complete_value => :true
+      scoped_search :on => :id, :complete_value => :true
+    end
+  end
+end
+

--- a/app/models/concerns/search_scope/config_group.rb
+++ b/app/models/concerns/search_scope/config_group.rb
@@ -1,0 +1,12 @@
+module SearchScope
+  module ConfigGroup
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => true
+      scoped_search :on => :hosts_count
+      scoped_search :on => :hostgroups_count
+      scoped_search :on => :config_group_classes_count
+    end
+  end
+end

--- a/app/models/concerns/search_scope/config_template.rb
+++ b/app/models/concerns/search_scope/config_template.rb
@@ -1,0 +1,17 @@
+module SearchScope
+  module ConfigTemplate
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name,    :complete_value => true, :default_order => true
+      scoped_search :on => :locked,  :complete_value => true, :complete_value => {:true => true, :false => false}
+      scoped_search :on => :snippet, :complete_value => true, :complete_value => {:true => true, :false => false}
+      scoped_search :on => :template
+
+      scoped_search :in => :operatingsystems, :on => :name, :rename => :operatingsystem, :complete_value => true
+      scoped_search :in => :environments,     :on => :name, :rename => :environment,     :complete_value => true
+      scoped_search :in => :hostgroups,       :on => :name, :rename => :hostgroup,       :complete_value => true
+      scoped_search :in => :template_kind,    :on => :name, :rename => :kind,            :complete_value => true
+    end
+  end
+end

--- a/app/models/concerns/search_scope/domain.rb
+++ b/app/models/concerns/search_scope/domain.rb
@@ -1,0 +1,13 @@
+module SearchScope
+  module Domain
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => [:name, :fullname], :complete_value => true
+      scoped_search :on => :hosts_count
+      scoped_search :on => :hostgroups_count
+      scoped_search :in => :domain_parameters,    :on => :value, :on_key=> :name, :complete_value => true, :only_explicit => true, :rename => :params
+    end
+  end
+end
+

--- a/app/models/concerns/search_scope/environment.rb
+++ b/app/models/concerns/search_scope/environment.rb
@@ -1,0 +1,11 @@
+module SearchScope
+  module Environment
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => :true
+      scoped_search :on => :hosts_count
+      scoped_search :on => :hostgroups_count
+    end
+  end
+end

--- a/app/models/concerns/search_scope/fact_value.rb
+++ b/app/models/concerns/search_scope/fact_value.rb
@@ -1,0 +1,27 @@
+module SearchScope
+  module FactValue
+    extend ActiveSupport::Concern
+
+    included do
+      include ScopedSearchExtensions
+
+      scoped_search :on => :value, :in_key=> :fact_name, :on_key=> :name, :rename => :facts, :complete_value => true, :only_explicit => true
+      scoped_search :on => :value, :default_order => true
+      scoped_search :in => :fact_name, :on => :name, :complete_value => true, :alias => "fact"
+      scoped_search :in => :host,      :on => :name, :complete_value => true, :rename => :host, :ext_method => :search_by_host, :only_explicit => true
+      scoped_search :in => :hostgroup, :on => :name, :complete_value => true, :rename => :"host.hostgroup", :only_explicit => true
+      scoped_search :in => :fact_name, :on => :short_name, :complete_value => true, :alias => "fact_short_name"
+    end
+
+    module ClassMethods
+      def search_by_host(key, operator, value)
+        search_term = value =~ /\A\d+\Z/ ? 'id' : 'name'
+        conditions = sanitize_sql_for_conditions(["hosts.#{search_term} #{operator} ?", value_to_sql(operator, value)])
+        search     = ::FactValue.joins(:host).where(conditions).select('fact_values.id').map(&:id).uniq
+
+        return { :conditions => "1=0" } if search.empty?
+        { :conditions => "fact_values.id IN(#{search.join(',')})" }
+      end
+    end
+  end
+end

--- a/app/models/concerns/search_scope/filter.rb
+++ b/app/models/concerns/search_scope/filter.rb
@@ -1,0 +1,29 @@
+module SearchScope
+  module Filter
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :search, :complete_value => true
+      scoped_search :on => :limited, :complete_value => { :true => true, :false => false }, :ext_method => :search_by_limited, :only_explicit => true
+      scoped_search :on => :unlimited, :complete_value => { :true => true, :false => false }, :ext_method => :search_by_unlimited, :only_explicit => true
+      scoped_search :in => :role, :on => :id, :rename => :role_id
+      scoped_search :in => :role, :on => :name, :rename => :role
+      scoped_search :in => :permissions, :on => :resource_type, :rename => :resource
+      scoped_search :in => :permissions, :on => :name,          :rename => :permission
+    end
+
+    module ClassMethods
+      def search_by_unlimited(key, operator, value)
+        search_by_limited(key, operator, value == 'true' ? 'false' : 'true')
+      end
+
+      def search_by_limited(key, operator, value)
+        value      = value == 'true'
+        value      = !value if operator == '<>'
+        conditions = value ? limited.where_values.join(' AND ') : unlimited.where_values.map(&:to_sql).join(' AND ')
+        { :conditions => conditions }
+      end
+    end
+  end
+end
+

--- a/app/models/concerns/search_scope/host.rb
+++ b/app/models/concerns/search_scope/host.rb
@@ -1,5 +1,5 @@
-module Hostext
-  module Search
+module SearchScope
+  module Host
     extend ActiveSupport::Concern
 
     included do
@@ -16,13 +16,13 @@ module Hostext
       scoped_search :on => :managed,       :complete_value => {:true => true, :false => false}
       scoped_search :on => :owner_type,    :complete_value => true, :only_explicit => true
       scoped_search :on => :owner_id,      :complete_value => false, :only_explicit => true, :complete_enabled => false
-      scoped_search :on => :puppet_status, :offset => 0, :word_size => Report::BIT_NUM*4, :complete_value => {:true => true, :false => false}, :rename => :'status.interesting'
-      scoped_search :on => :puppet_status, :offset => Report::METRIC.index("applied"),         :word_size => Report::BIT_NUM, :rename => :'status.applied'
-      scoped_search :on => :puppet_status, :offset => Report::METRIC.index("restarted"),       :word_size => Report::BIT_NUM, :rename => :'status.restarted'
-      scoped_search :on => :puppet_status, :offset => Report::METRIC.index("failed"),          :word_size => Report::BIT_NUM, :rename => :'status.failed'
-      scoped_search :on => :puppet_status, :offset => Report::METRIC.index("failed_restarts"), :word_size => Report::BIT_NUM, :rename => :'status.failed_restarts'
-      scoped_search :on => :puppet_status, :offset => Report::METRIC.index("skipped"),         :word_size => Report::BIT_NUM, :rename => :'status.skipped'
-      scoped_search :on => :puppet_status, :offset => Report::METRIC.index("pending"),         :word_size => Report::BIT_NUM, :rename => :'status.pending'
+      scoped_search :on => :puppet_status, :offset => 0, :word_size => ::Report::BIT_NUM * 4, :complete_value => {:true => true, :false => false}, :rename => :'status.interesting'
+      scoped_search :on => :puppet_status, :offset => ::Report::METRIC.index("applied"),         :word_size => ::Report::BIT_NUM, :rename => :'status.applied'
+      scoped_search :on => :puppet_status, :offset => ::Report::METRIC.index("restarted"),       :word_size => ::Report::BIT_NUM, :rename => :'status.restarted'
+      scoped_search :on => :puppet_status, :offset => ::Report::METRIC.index("failed"),          :word_size => ::Report::BIT_NUM, :rename => :'status.failed'
+      scoped_search :on => :puppet_status, :offset => ::Report::METRIC.index("failed_restarts"), :word_size => ::Report::BIT_NUM, :rename => :'status.failed_restarts'
+      scoped_search :on => :puppet_status, :offset => ::Report::METRIC.index("skipped"),         :word_size => ::Report::BIT_NUM, :rename => :'status.skipped'
+      scoped_search :on => :puppet_status, :offset => ::Report::METRIC.index("pending"),         :word_size => ::Report::BIT_NUM, :rename => :'status.pending'
 
       scoped_search :in => :model,       :on => :name,    :complete_value => true,  :rename => :model
       scoped_search :in => :hostgroup,   :on => :name,    :complete_value => true,  :rename => :hostgroup

--- a/app/models/concerns/search_scope/hostgroup.rb
+++ b/app/models/concerns/search_scope/hostgroup.rb
@@ -1,0 +1,41 @@
+module SearchScope
+  module Hostgroup
+    extend ActiveSupport::Concern
+
+    included do
+      include ScopedSearchExtensions
+
+      scoped_search :on => :name, :complete_value => :true
+      scoped_search :in => :group_parameters,    :on => :value, :on_key=> :name, :complete_value => true, :only_explicit => true, :rename => :params
+      scoped_search :in => :hosts, :on => :name, :complete_value => :true, :rename => "host"
+      scoped_search :in => :puppetclasses, :on => :name, :complete_value => true, :rename => :class, :operators => ['= ', '~ ']
+      scoped_search :in => :environment, :on => :name, :complete_value => :true, :rename => :environment
+      scoped_search :on => :id, :complete_value => :true
+      # for legacy purposes, keep search on :label
+      scoped_search :on => :title, :complete_value => true, :rename => :label
+      scoped_search :in => :config_groups, :on => :name, :complete_value => true, :rename => :config_group, :only_explicit => true, :operators => ['= ', '~ '], :ext_method => :search_by_config_group
+      if SETTINGS[:unattended]
+        scoped_search :in => :architecture, :on => :name, :complete_value => :true, :rename => :architecture
+        scoped_search :in => :operatingsystem, :on => :name, :complete_value => true, :rename => :os
+        scoped_search :in => :operatingsystem,  :on => :description, :complete_value => true,  :rename => :os_description
+        scoped_search :in => :operatingsystem,  :on => :title,       :complete_value => true,  :rename => :os_title
+        scoped_search :in => :operatingsystem,  :on => :major,       :complete_value => true,  :rename => :os_major
+        scoped_search :in => :operatingsystem,  :on => :minor,       :complete_value => true,  :rename => :os_minor
+        scoped_search :in => :operatingsystem,  :on => :id,          :complete_value => false, :rename => :os_id, :complete_enabled => false
+        scoped_search :in => :medium,            :on => :name, :complete_value => :true, :rename => "medium"
+        scoped_search :in => :config_templates, :on => :name, :complete_value => :true, :rename => "template"
+      end
+    end
+
+    module ClassMethods
+      def search_by_config_group(key, operator, value)
+        conditions  = sanitize_sql_for_conditions(["config_groups.name #{operator} ?", value_to_sql(operator, value)])
+        hostgroup_ids = ::Hostgroup.unscoped.with_taxonomy_scope.joins(:config_groups).where(conditions).map(&:subtree_ids).flatten.uniq
+
+        opts = 'hostgroups.id < 0'
+        opts = "hostgroups.id IN(#{hostgroup_ids.join(',')})" unless hostgroup_ids.blank?
+        {:conditions => opts}
+      end
+    end
+  end
+end

--- a/app/models/concerns/search_scope/image.rb
+++ b/app/models/concerns/search_scope/image.rb
@@ -1,0 +1,13 @@
+module SearchScope
+  module Image
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => [:name, :username], :complete_value => true
+      scoped_search :in => :compute_resources, :on => :name, :complete_value => :true, :rename => "compute_resource"
+      scoped_search :in => :architecture, :on => :id, :rename => "architecture"
+      scoped_search :in => :operatingsystem, :on => :id, :rename => "operatingsystem"
+      scoped_search :on => :user_data, :complete_value => {:true => true, :false => false}
+    end
+  end
+end

--- a/app/models/concerns/search_scope/lookup_key.rb
+++ b/app/models/concerns/search_scope/lookup_key.rb
@@ -1,0 +1,15 @@
+module SearchScope
+  module LookupKey
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :key, :complete_value => true, :default_order => true
+      scoped_search :on => :lookup_values_count, :rename => :values_count
+      scoped_search :on => :override, :complete_value => {:true => true, :false => false}
+      scoped_search :on => :merge_overrides, :complete_value => {:true => true, :false => false}
+      scoped_search :on => :avoid_duplicates, :complete_value => {:true => true, :false => false}
+      scoped_search :in => :param_classes, :on => :name, :rename => :puppetclass, :complete_value => true
+      scoped_search :in => :lookup_values, :on => :value, :rename => :value, :complete_value => true
+    end
+  end
+end

--- a/app/models/concerns/search_scope/mail_notification.rb
+++ b/app/models/concerns/search_scope/mail_notification.rb
@@ -1,0 +1,11 @@
+module SearchScope
+  module MailNotification
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => true
+      scoped_search :on => :description, :complete_value => true
+      scoped_search :in => :users, :on => :login, :complete_value => true, :rename => :user
+    end
+  end
+end

--- a/app/models/concerns/search_scope/medium.rb
+++ b/app/models/concerns/search_scope/medium.rb
@@ -1,0 +1,12 @@
+module SearchScope
+  module Medium
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => :true, :default_order => true
+      scoped_search :on => :path, :complete_value => :true
+      scoped_search :on => :os_family, :rename => "family", :complete_value => :true
+    end
+  end
+end
+

--- a/app/models/concerns/search_scope/model.rb
+++ b/app/models/concerns/search_scope/model.rb
@@ -1,0 +1,13 @@
+module SearchScope
+  module Model
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => :true, :default_order => true
+      scoped_search :on => :info
+      scoped_search :on => :hosts_count
+      scoped_search :on => :vendor_class, :complete_value => :true
+      scoped_search :on => :hardware_model, :complete_value => :true
+    end
+  end
+end

--- a/app/models/concerns/search_scope/nested_ancestry.rb
+++ b/app/models/concerns/search_scope/nested_ancestry.rb
@@ -1,0 +1,10 @@
+module SearchScope
+  module NestedAncestry
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :title, :complete_value => true, :default_order => true
+      scoped_search :on => :name, :complete_value => :true
+    end
+  end
+end

--- a/app/models/concerns/search_scope/operatingsystem.rb
+++ b/app/models/concerns/search_scope/operatingsystem.rb
@@ -1,0 +1,22 @@
+module SearchScope
+  module Operatingsystem
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name,        :complete_value => :true
+      scoped_search :on => :major,       :complete_value => :true
+      scoped_search :on => :minor,       :complete_value => :true
+      scoped_search :on => :description, :complete_value => :true
+      scoped_search :on => :type,        :complete_value => :true, :rename => "family"
+      scoped_search :on => :title,       :complete_value => :true
+      scoped_search :on => :hosts_count
+      scoped_search :on => :hostgroups_count
+
+      scoped_search :in => :architectures,    :on => :name,  :complete_value => :true, :rename => "architecture", :only_explicit => true
+      scoped_search :in => :media,            :on => :name,  :complete_value => :true, :rename => "medium", :only_explicit => true
+      scoped_search :in => :config_templates, :on => :name,  :complete_value => :true, :rename => "template", :only_explicit => true
+      scoped_search :in => :os_parameters,    :on => :value, :on_key=> :name, :complete_value => true, :rename => :params, :only_explicit => true
+
+    end
+  end
+end

--- a/app/models/concerns/search_scope/partition_table.rb
+++ b/app/models/concerns/search_scope/partition_table.rb
@@ -1,0 +1,11 @@
+module SearchScope
+  module PartitionTable
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => true, :default_order => true
+      scoped_search :on => :layout, :complete_value => false
+      scoped_search :on => :os_family, :rename => "family", :complete_value => :true
+    end
+  end
+end

--- a/app/models/concerns/search_scope/puppetclass.rb
+++ b/app/models/concerns/search_scope/puppetclass.rb
@@ -1,0 +1,19 @@
+module SearchScope
+  module Puppetclass
+    extend ActiveSupport::Concern
+
+    included do
+      include ScopedSearchExtensions
+
+      scoped_search :on => :name, :complete_value => :true
+      scoped_search :on => :total_hosts
+      scoped_search :on => :global_class_params_count, :rename => :params_count   # Smart Parameters
+      scoped_search :on => :lookup_keys_count, :rename => :variables_count        # Smart Variables
+      scoped_search :in => :environments, :on => :name, :complete_value => :true, :rename => "environment"
+      scoped_search :in => :hostgroups,   :on => :name, :complete_value => :true, :rename => "hostgroup"
+      scoped_search :in => :config_groups,   :on => :name, :complete_value => :true, :rename => "config_group"
+      scoped_search :in => :hosts, :on => :name, :complete_value => :true, :rename => "host", :ext_method => :search_by_host, :only_explicit => true
+      scoped_search :in => :class_params, :on => :key, :complete_value => :true, :only_explicit => true
+    end
+  end
+end

--- a/app/models/concerns/search_scope/realm.rb
+++ b/app/models/concerns/search_scope/realm.rb
@@ -1,0 +1,11 @@
+module SearchScope
+  module Realm
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :hosts_count
+      scoped_search :on => :name, :complete_value => true
+      scoped_search :on => :realm_type, :complete_value => true, :rename => :type
+    end
+  end
+end

--- a/app/models/concerns/search_scope/report.rb
+++ b/app/models/concerns/search_scope/report.rb
@@ -1,0 +1,25 @@
+module SearchScope
+  module Report
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :in => :host,        :on => :name,  :complete_value => true, :rename => :host
+      scoped_search :in => :environment, :on => :name,  :complete_value => true, :rename => :environment
+      scoped_search :in => :messages,    :on => :value,                          :rename => :log
+      scoped_search :in => :sources,     :on => :value,                          :rename => :resource
+      scoped_search :in => :hostgroup,   :on => :name,  :complete_value => true, :rename => :hostgroup
+      scoped_search :in => :hostgroup,   :on => :title, :complete_value => true, :rename => :hostgroup_fullname
+      scoped_search :in => :hostgroup,   :on => :title, :complete_value => true, :rename => :hostgroup_title
+
+      scoped_search :on => :reported_at, :complete_value => true, :default_order => :desc,    :rename => :reported, :only_explicit => true
+      scoped_search :on => :status, :offset => 0, :word_size => 4 * self::BIT_NUM, :complete_value => {:true => true, :false => false}, :rename => :eventful
+
+      scoped_search :on => :status, :offset => self::METRIC.index("applied"),         :word_size => self::BIT_NUM, :rename => :applied
+      scoped_search :on => :status, :offset => self::METRIC.index("restarted"),       :word_size => self::BIT_NUM, :rename => :restarted
+      scoped_search :on => :status, :offset => self::METRIC.index("failed"),          :word_size => self::BIT_NUM, :rename => :failed
+      scoped_search :on => :status, :offset => self::METRIC.index("failed_restarts"), :word_size => self::BIT_NUM, :rename => :failed_restarts
+      scoped_search :on => :status, :offset => self::METRIC.index("skipped"),         :word_size => self::BIT_NUM, :rename => :skipped
+      scoped_search :on => :status, :offset => self::METRIC.index("pending"),         :word_size => self::BIT_NUM, :rename => :pending
+    end
+  end
+end

--- a/app/models/concerns/search_scope/setting.rb
+++ b/app/models/concerns/search_scope/setting.rb
@@ -1,0 +1,10 @@
+module SearchScope
+  module Setting
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => :true
+      scoped_search :on => :description, :complete_value => :true
+    end
+  end
+end

--- a/app/models/concerns/search_scope/smart_proxy.rb
+++ b/app/models/concerns/search_scope/smart_proxy.rb
@@ -1,0 +1,12 @@
+module SearchScope
+  module SmartProxy
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :name, :complete_value => :true
+      scoped_search :on => :url, :complete_value => :true
+      scoped_search :in => :features, :on => :name, :rename => :feature, :complete_value => :true
+    end
+  end
+end
+

--- a/app/models/concerns/search_scope/subnet.rb
+++ b/app/models/concerns/search_scope/subnet.rb
@@ -1,0 +1,12 @@
+module SearchScope
+  module Subnet
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => [:name, :network, :mask, :gateway, :dns_primary, :dns_secondary,
+                            :vlanid, :ipam, :boot_mode], :complete_value => true
+      scoped_search :in => :domains, :on => :name, :rename => :domain, :complete_value => true
+    end
+  end
+end
+

--- a/app/models/concerns/search_scope/taxonomix.rb
+++ b/app/models/concerns/search_scope/taxonomix.rb
@@ -1,0 +1,12 @@
+module SearchScope
+  module Taxonomix
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :in => :locations, :on => :name, :rename => :location, :complete_value => true
+      scoped_search :in => :locations, :on => :id, :rename => :location_id, :complete_value => true
+      scoped_search :in => :organizations, :on => :name, :rename => :organization, :complete_value => true
+      scoped_search :in => :organizations, :on => :id, :rename => :organization_id, :complete_value => true
+    end
+  end
+end

--- a/app/models/concerns/search_scope/user.rb
+++ b/app/models/concerns/search_scope/user.rb
@@ -1,0 +1,34 @@
+module SearchScope
+  module User
+    extend ActiveSupport::Concern
+
+    included do
+      scoped_search :on => :login, :complete_value => :true
+      scoped_search :on => :firstname, :complete_value => :true
+      scoped_search :on => :lastname, :complete_value => :true
+      scoped_search :on => :mail, :complete_value => :true
+      scoped_search :on => :admin, :complete_value => { :true => true, :false => false }, :ext_method => :search_by_admin
+      scoped_search :on => :last_login_on, :complete_value => :true, :only_explicit => true
+      scoped_search :in => :roles, :on => :name, :rename => :role, :complete_value => true
+      scoped_search :in => :roles, :on => :id, :rename => :role_id
+      scoped_search :in => :cached_usergroups, :on => :name, :rename => :usergroup, :complete_value => true
+    end
+
+    module ClassMethods
+      def search_by_admin(key, operator, value)
+        value      = value == 'true'
+        value      = !value if operator == '<>'
+        conditions = [self.table_name, Usergroup.table_name].map do |base|
+          "(#{base}.admin = ?" + (value ? ')' : " OR #{base}.admin IS NULL)")
+        end
+        conditions = conditions.join(value ? ' OR ' : ' AND ')
+
+        {
+          :include    => :cached_usergroups,
+          :conditions => sanitize_sql_for_conditions([conditions, value, value])
+        }
+      end
+    end
+  end
+end
+

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -1,6 +1,7 @@
 module Taxonomix
   extend ActiveSupport::Concern
   include DirtyAssociations
+  include SearchScope::Taxonomix
 
   included do
     taxonomy_join_table = "taxable_taxonomies"
@@ -10,19 +11,11 @@ module Taxonomix
     has_many :organizations, :through => taxonomy_join_table, :source => :taxonomy,
              :conditions => "taxonomies.type='Organization'", :validate => false
     after_initialize :set_current_taxonomy
-
-    scoped_search :in => :locations, :on => :name, :rename => :location, :complete_value => true
-    scoped_search :in => :locations, :on => :id, :rename => :location_id, :complete_value => true
-    scoped_search :in => :organizations, :on => :name, :rename => :organization, :complete_value => true
-    scoped_search :in => :organizations, :on => :id, :rename => :organization_id, :complete_value => true
-
     dirty_has_many_associations :organizations, :locations
-
     validate :ensure_taxonomies_not_escalated, :if => Proc.new { User.current.nil? || !User.current.admin? }
   end
 
   module ClassMethods
-
     attr_accessor :which_ancestry_method, :which_location, :which_organization
 
     # default inner_method includes children (subtree_ids)

--- a/app/models/config_group.rb
+++ b/app/models/config_group.rb
@@ -3,6 +3,7 @@ class ConfigGroup < ActiveRecord::Base
   include Authorizable
   include Parameterizable::ByIdName
   include PuppetclassTotalHosts::Indirect
+  include SearchScope::ConfigGroup
 
   validates_lengths_from_database
 
@@ -14,11 +15,6 @@ class ConfigGroup < ActiveRecord::Base
   has_many_hosts :through => :host_config_groups
 
   validates :name, :presence => true, :uniqueness => true
-
-  scoped_search :on => :name, :complete_value => true
-  scoped_search :on => :hosts_count
-  scoped_search :on => :hostgroups_count
-  scoped_search :on => :config_group_classes_count
 
   default_scope lambda { order('config_groups.name') }
 

--- a/app/models/config_template.rb
+++ b/app/models/config_template.rb
@@ -4,6 +4,7 @@ class ConfigTemplate < ActiveRecord::Base
   friendly_id :name
   include Taxonomix
   include Parameterizable::ByIdName
+  include SearchScope::ConfigTemplate
 
   validates_lengths_from_database
   audited :allow_mass_assignment => true
@@ -33,16 +34,6 @@ class ConfigTemplate < ActiveRecord::Base
       order("config_templates.name")
     end
   }
-
-  scoped_search :on => :name,    :complete_value => true, :default_order => true
-  scoped_search :on => :locked,  :complete_value => true, :complete_value => {:true => true, :false => false}
-  scoped_search :on => :snippet, :complete_value => true, :complete_value => {:true => true, :false => false}
-  scoped_search :on => :template
-
-  scoped_search :in => :operatingsystems, :on => :name, :rename => :operatingsystem, :complete_value => true
-  scoped_search :in => :environments,     :on => :name, :rename => :environment,     :complete_value => true
-  scoped_search :in => :hostgroups,       :on => :name, :rename => :hostgroup,       :complete_value => true
-  scoped_search :in => :template_kind,    :on => :name, :rename => :kind,            :complete_value => true
 
   class Jail < Safemode::Jail
     allow :name

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -7,6 +7,7 @@ class Domain < ActiveRecord::Base
   include Taxonomix
   include StripLeadingAndTrailingDot
   include Parameterizable::ByIdName
+  include SearchScope::Domain
 
   audited :allow_mass_assignment => true
 
@@ -26,11 +27,6 @@ class Domain < ActiveRecord::Base
   include ParameterValidators
   validates :name, :presence => true, :uniqueness => true
   validates :fullname, :uniqueness => true, :allow_blank => true, :allow_nil => true
-
-  scoped_search :on => [:name, :fullname], :complete_value => true
-  scoped_search :on => :hosts_count
-  scoped_search :on => :hostgroups_count
-  scoped_search :in => :domain_parameters,    :on => :value, :on_key=> :name, :complete_value => true, :only_explicit => true, :rename => :params
 
   # with proc support, default_scope can no longer be chained
   # include all default scoping here

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -4,6 +4,7 @@ class Environment < ActiveRecord::Base
   include Taxonomix
   include Authorizable
   include Parameterizable::ByName
+  include SearchScope::Environment
 
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
@@ -26,12 +27,7 @@ class Environment < ActiveRecord::Base
     end
   }
 
-  scoped_search :on => :name, :complete_value => :true
-  scoped_search :on => :hosts_count
-  scoped_search :on => :hostgroups_count
-
   class << self
-
     #TODO: this needs to be removed, as PuppetDOC generation no longer works
     # if the manifests are not on the foreman host
     # returns an hash of all puppet environments and their relative paths

--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -1,6 +1,6 @@
 class FactValue < ActiveRecord::Base
   include Authorizable
-  include ScopedSearchExtensions
+  include SearchScope::FactValue
 
   belongs_to_host
   belongs_to :fact_name
@@ -8,13 +8,6 @@ class FactValue < ActiveRecord::Base
   has_many :hostgroup, :through => :host
 
   has_one :parent_fact_name, :through => :fact_name, :source => :parent
-
-  scoped_search :on => :value, :in_key=> :fact_name, :on_key=> :name, :rename => :facts, :complete_value => true, :only_explicit => true
-  scoped_search :on => :value, :default_order => true
-  scoped_search :in => :fact_name, :on => :name, :complete_value => true, :alias => "fact"
-  scoped_search :in => :host,      :on => :name, :complete_value => true, :rename => :host, :ext_method => :search_by_host, :only_explicit => true
-  scoped_search :in => :hostgroup, :on => :name, :complete_value => true, :rename => :"host.hostgroup", :only_explicit => true
-  scoped_search :in => :fact_name, :on => :short_name, :complete_value => true, :alias => "fact_short_name"
 
   scope :no_timestamp_facts, lambda {
     includes(:fact_name).where("fact_names.name <> ?",:_timestamp)
@@ -37,15 +30,6 @@ class FactValue < ActiveRecord::Base
   scope :root_only, lambda { with_roots.where(:fact_names => {:ancestry => nil}) }
 
   validates :fact_name_id, :uniqueness => { :scope => :host_id }
-
-  def self.search_by_host(key, operator, value)
-    search_term = value =~ /\A\d+\Z/ ? 'id' : 'name'
-    conditions = sanitize_sql_for_conditions(["hosts.#{search_term} #{operator} ?", value_to_sql(operator, value)])
-    search     = FactValue.joins(:host).where(conditions).select('fact_values.id').map(&:id).uniq
-
-    return { :conditions => "1=0" } if search.empty?
-    { :conditions => "fact_values.id IN(#{search.join(',')})" }
-  end
 
   # Todo: find a way to filter which values are logged,
   # this generates too much useless data

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -1,6 +1,6 @@
 class Host::Managed < Host::Base
   include ReportCommon
-  include Hostext::Search
+  include SearchScope::Host
   PROVISION_METHODS = %w[build image]
 
   has_many :host_classes, :foreign_key => :host_id

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -5,8 +5,8 @@ class Hostgroup < ActiveRecord::Base
   include Taxonomix
   include HostCommon
   include NestedAncestryCommon
-  include ScopedSearchExtensions
   include PuppetclassTotalHosts::Indirect
+  include SearchScope::Hostgroup
 
   validates_lengths_from_database :except => [:name]
   before_destroy EnsureNotUsedBy.new(:hosts)
@@ -38,37 +38,6 @@ class Hostgroup < ActiveRecord::Base
       order("hostgroups.title")
     end
   }
-
-  scoped_search :on => :name, :complete_value => :true
-  scoped_search :in => :group_parameters,    :on => :value, :on_key=> :name, :complete_value => true, :only_explicit => true, :rename => :params
-  scoped_search :in => :hosts, :on => :name, :complete_value => :true, :rename => "host"
-  scoped_search :in => :puppetclasses, :on => :name, :complete_value => true, :rename => :class, :operators => ['= ', '~ ']
-  scoped_search :in => :environment, :on => :name, :complete_value => :true, :rename => :environment
-  scoped_search :on => :id, :complete_value => :true
-  # for legacy purposes, keep search on :label
-  scoped_search :on => :title, :complete_value => true, :rename => :label
-  scoped_search :in => :config_groups, :on => :name, :complete_value => true, :rename => :config_group, :only_explicit => true, :operators => ['= ', '~ '], :ext_method => :search_by_config_group
-
-  def self.search_by_config_group(key, operator, value)
-    conditions  = sanitize_sql_for_conditions(["config_groups.name #{operator} ?", value_to_sql(operator, value)])
-    hostgroup_ids = Hostgroup.unscoped.with_taxonomy_scope.joins(:config_groups).where(conditions).map(&:subtree_ids).flatten.uniq
-
-    opts = 'hostgroups.id < 0'
-    opts = "hostgroups.id IN(#{hostgroup_ids.join(',')})" unless hostgroup_ids.blank?
-    {:conditions => opts}
-  end
-
-  if SETTINGS[:unattended]
-    scoped_search :in => :architecture,     :on => :name,        :complete_value => true,  :rename => :architecture
-    scoped_search :in => :operatingsystem,  :on => :name,        :complete_value => true,  :rename => :os
-    scoped_search :in => :operatingsystem,  :on => :description, :complete_value => true,  :rename => :os_description
-    scoped_search :in => :operatingsystem,  :on => :title,       :complete_value => true,  :rename => :os_title
-    scoped_search :in => :operatingsystem,  :on => :major,       :complete_value => true,  :rename => :os_major
-    scoped_search :in => :operatingsystem,  :on => :minor,       :complete_value => true,  :rename => :os_minor
-    scoped_search :in => :operatingsystem,  :on => :id,          :complete_value => false, :rename => :os_id, :complete_enabled => false
-    scoped_search :in => :medium,           :on => :name,        :complete_value => true,  :rename => "medium"
-    scoped_search :in => :config_templates, :on => :name,        :complete_value => true,  :rename => "template"
-  end
 
   # returns reports for hosts in the User's filter set
   scope :my_groups, lambda {

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,6 @@
 class Image < ActiveRecord::Base
   include Authorizable
+  include SearchScope::Image
 
   audited :allow_mass_assignment => true
 
@@ -12,11 +13,4 @@ class Image < ActiveRecord::Base
   validates_lengths_from_database
   validates :username, :name, :operatingsystem_id, :compute_resource_id, :architecture_id, :presence => true
   validates :uuid, :presence => true, :uniqueness => {:scope => :compute_resource_id}
-
-  scoped_search :on => [:name, :username], :complete_value => true
-  scoped_search :in => :compute_resources, :on => :name, :complete_value => :true, :rename => "compute_resource"
-  scoped_search :in => :architecture, :on => :id, :rename => "architecture"
-  scoped_search :in => :operatingsystem, :on => :id, :rename => "operatingsystem"
-  scoped_search :on => :user_data, :complete_value => {:true => true, :false => false}
-
 end

--- a/app/models/lookup_key.rb
+++ b/app/models/lookup_key.rb
@@ -1,6 +1,7 @@
 class LookupKey < ActiveRecord::Base
   include Authorizable
   include CounterCacheFix
+  include SearchScope::LookupKey
 
   KEY_TYPES = [N_("string"), N_("boolean"), N_("integer"), N_("real"), N_("array"), N_("hash"), N_("yaml"), N_("json")]
   VALIDATOR_TYPES = [N_("regexp"), N_("list") ]
@@ -46,14 +47,6 @@ class LookupKey < ActiveRecord::Base
 
   before_save :sanitize_path
   attr_name :key
-
-  scoped_search :on => :key, :complete_value => true, :default_order => true
-  scoped_search :on => :lookup_values_count, :rename => :values_count
-  scoped_search :on => :override, :complete_value => {:true => true, :false => false}
-  scoped_search :on => :merge_overrides, :complete_value => {:true => true, :false => false}
-  scoped_search :on => :avoid_duplicates, :complete_value => {:true => true, :false => false}
-  scoped_search :in => :param_classes, :on => :name, :rename => :puppetclass, :complete_value => true
-  scoped_search :in => :lookup_values, :on => :value, :rename => :value, :complete_value => true
 
   default_scope lambda { order('lookup_keys.key') }
 

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -19,10 +19,6 @@ class LookupValue < ActiveRecord::Base
 
   scope :default, lambda { where(:match => "default").limit(1) }
 
-  scoped_search :on => :value, :complete_value => true, :default_order => true
-  scoped_search :on => :match, :complete_value => true
-  scoped_search :in => :lookup_key, :on => :key, :rename => :lookup_key, :complete_value => true
-
   def name
     match
   end

--- a/app/models/mail_notification.rb
+++ b/app/models/mail_notification.rb
@@ -1,5 +1,6 @@
 class MailNotification < ActiveRecord::Base
   include Authorizable
+  include SearchScope::MailNotification
 
   INTERVALS = [N_("Daily"), N_("Weekly"), N_("Monthly")]
   SUBSCRIPTION_TYPES = %w(alert report)
@@ -8,10 +9,6 @@ class MailNotification < ActiveRecord::Base
 
   has_many :user_mail_notifications, :dependent => :destroy
   has_many :users, :through => :user_mail_notifications
-
-  scoped_search :on => :name, :complete_value => true
-  scoped_search :on => :description, :complete_value => true
-  scoped_search :in => :users, :on => :login, :complete_value => true, :rename => :user
 
   scope :subscriptable, lambda { where(:subscriptable => true) }
 

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -5,6 +5,7 @@ class Medium < ActiveRecord::Base
   include Taxonomix
   include ValidateOsFamily
   include Parameterizable::ByIdName
+  include SearchScope::Medium
   audited :allow_mass_assignment => true
 
   validates_lengths_from_database
@@ -35,9 +36,6 @@ class Medium < ActiveRecord::Base
       order("media.name")
     end
   }
-  scoped_search :on => :name, :complete_value => :true, :default_order => true
-  scoped_search :on => :path, :complete_value => :true
-  scoped_search :on => :os_family, :rename => "family", :complete_value => :true
 
   def media_host
     media_path.match(VALID_NFS_PATH)[1]

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -1,5 +1,6 @@
 class Model < ActiveRecord::Base
   include Authorizable
+  include SearchScope::Model
   extend FriendlyId
   friendly_id :name
 
@@ -10,10 +11,4 @@ class Model < ActiveRecord::Base
   validates :name, :uniqueness => true, :presence => true
 
   default_scope lambda { order('models.name') }
-
-  scoped_search :on => :name, :complete_value => :true, :default_order => true
-  scoped_search :on => :info
-  scoped_search :on => :hosts_count
-  scoped_search :on => :vendor_class, :complete_value => :true
-  scoped_search :on => :hardware_model, :complete_value => :true
 end

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -4,6 +4,7 @@ require 'uri'
 class Operatingsystem < ActiveRecord::Base
   include Authorizable
   include ValidateOsFamily
+  include SearchScope::Operatingsystem
   extend FriendlyId
   friendly_id :title
 
@@ -39,20 +40,6 @@ class Operatingsystem < ActiveRecord::Base
 
   audited :allow_mass_assignment => true
   default_scope lambda { order('operatingsystems.name') }
-
-  scoped_search :on => :name,        :complete_value => :true
-  scoped_search :on => :major,       :complete_value => :true
-  scoped_search :on => :minor,       :complete_value => :true
-  scoped_search :on => :description, :complete_value => :true
-  scoped_search :on => :type,        :complete_value => :true, :rename => "family"
-  scoped_search :on => :title,       :complete_value => :true
-  scoped_search :on => :hosts_count
-  scoped_search :on => :hostgroups_count
-
-  scoped_search :in => :architectures,    :on => :name,  :complete_value => :true, :rename => "architecture", :only_explicit => true
-  scoped_search :in => :media,            :on => :name,  :complete_value => :true, :rename => "medium", :only_explicit => true
-  scoped_search :in => :config_templates, :on => :name,  :complete_value => :true, :rename => "template", :only_explicit => true
-  scoped_search :in => :os_parameters,    :on => :value, :on_key=> :name, :complete_value => true, :rename => :params, :only_explicit => true
 
   FAMILIES = { 'Debian'    => %r{Debian|Ubuntu}i,
                'Redhat'    => %r{RedHat|Centos|Fedora|Scientific|SLC|OracleLinux}i,

--- a/app/models/parameters/common_parameter.rb
+++ b/app/models/parameters/common_parameter.rb
@@ -1,7 +1,5 @@
 class CommonParameter < Parameter
+  include SearchScope::CommonParameter
   audited :except => [:priority], :allow_mass_assignment => true
   validates :name, :uniqueness => true
-
-  scoped_search :on => :name, :complete_value => :true
-  scoped_search :on => :value, :complete_value => :true
 end

--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -4,6 +4,7 @@
 # modified version of one of these in textual form
 class Ptable < ActiveRecord::Base
   include Authorizable
+  include SearchScope::PartitionTable
   extend FriendlyId
   friendly_id :name
   include ValidateOsFamily
@@ -19,12 +20,7 @@ class Ptable < ActiveRecord::Base
   default_scope lambda { order('ptables.name') }
   validate_inclusion_in_families :os_family
 
-  scoped_search :on => :name, :complete_value => true, :default_order => true
-  scoped_search :on => :layout, :complete_value => false
-  scoped_search :on => :os_family, :rename => "family", :complete_value => :true
-
   def skip_strip_attrs
     ['layout']
   end
-
 end

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -1,9 +1,9 @@
 class Puppetclass < ActiveRecord::Base
   include Authorizable
-  include ScopedSearchExtensions
   extend FriendlyId
   friendly_id :name
   include Parameterizable::ByIdName
+  include SearchScope::Puppetclass
 
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
@@ -32,16 +32,6 @@ class Puppetclass < ActiveRecord::Base
   alias_attribute :smart_class_parameter_ids, :class_param_ids
 
   default_scope lambda { order('puppetclasses.name') }
-
-  scoped_search :on => :name, :complete_value => :true
-  scoped_search :on => :total_hosts
-  scoped_search :on => :global_class_params_count, :rename => :params_count   # Smart Parameters
-  scoped_search :on => :lookup_keys_count, :rename => :variables_count        # Smart Variables
-  scoped_search :in => :environments, :on => :name, :complete_value => :true, :rename => "environment"
-  scoped_search :in => :hostgroups,   :on => :name, :complete_value => :true, :rename => "hostgroup"
-  scoped_search :in => :config_groups,   :on => :name, :complete_value => :true, :rename => "config_group"
-  scoped_search :in => :hosts, :on => :name, :complete_value => :true, :rename => "host", :ext_method => :search_by_host, :only_explicit => true
-  scoped_search :in => :class_params, :on => :key, :complete_value => :true, :only_explicit => true
 
   scope :not_in_any_environment, lambda { includes(:environment_classes).where(:environment_classes => {:environment_id => nil}) }
 

--- a/app/models/realm.rb
+++ b/app/models/realm.rb
@@ -3,6 +3,7 @@ class Realm < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name
   include Taxonomix
+  include SearchScope::Realm
 
   TYPES = ["FreeIPA", "Active Directory"]
 
@@ -13,10 +14,6 @@ class Realm < ActiveRecord::Base
   belongs_to :realm_proxy, :class_name => "SmartProxy"
   has_many_hosts
   has_many :hostgroups
-
-  scoped_search :on => :hosts_count
-  scoped_search :on => :name, :complete_value => true
-  scoped_search :on => :realm_type, :complete_value => true, :rename => :type
 
   validates :name, :presence => true, :uniqueness => true
   validates :realm_type, :presence => true, :inclusion => { :in => TYPES }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,6 +1,7 @@
 class Report < ActiveRecord::Base
   include Authorizable
   include ReportCommon
+  include SearchScope::Report
 
   validates_lengths_from_database
   belongs_to_host
@@ -12,24 +13,6 @@ class Report < ActiveRecord::Base
 
   validates :host_id, :status, :presence => true
   validates :reported_at, :presence => true, :uniqueness => {:scope => :host_id}
-
-  scoped_search :in => :host,        :on => :name,  :complete_value => true, :rename => :host
-  scoped_search :in => :environment, :on => :name,  :complete_value => true, :rename => :environment
-  scoped_search :in => :messages,    :on => :value,                          :rename => :log
-  scoped_search :in => :sources,     :on => :value,                          :rename => :resource
-  scoped_search :in => :hostgroup,   :on => :name,  :complete_value => true, :rename => :hostgroup
-  scoped_search :in => :hostgroup,   :on => :title, :complete_value => true, :rename => :hostgroup_fullname
-  scoped_search :in => :hostgroup,   :on => :title, :complete_value => true, :rename => :hostgroup_title
-
-  scoped_search :on => :reported_at, :complete_value => true, :default_order => :desc,    :rename => :reported, :only_explicit => true
-  scoped_search :on => :status, :offset => 0, :word_size => 4*BIT_NUM, :complete_value => {:true => true, :false => false}, :rename => :eventful
-
-  scoped_search :on => :status, :offset => METRIC.index("applied"),         :word_size => BIT_NUM, :rename => :applied
-  scoped_search :on => :status, :offset => METRIC.index("restarted"),       :word_size => BIT_NUM, :rename => :restarted
-  scoped_search :on => :status, :offset => METRIC.index("failed"),          :word_size => BIT_NUM, :rename => :failed
-  scoped_search :on => :status, :offset => METRIC.index("failed_restarts"), :word_size => BIT_NUM, :rename => :failed_restarts
-  scoped_search :on => :status, :offset => METRIC.index("skipped"),         :word_size => BIT_NUM, :rename => :skipped
-  scoped_search :on => :status, :offset => METRIC.index("pending"),         :word_size => BIT_NUM, :rename => :pending
 
   # returns reports for hosts in the User's filter set
   scope :my_reports, lambda {

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -2,6 +2,7 @@ class Setting < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name
   include ActiveModel::Validations
+  include SearchScope::Setting
   self.inheritance_column = 'category'
 
   TYPES= %w{ integer boolean hash array string }
@@ -43,9 +44,6 @@ class Setting < ActiveRecord::Base
 
   # The DB may contain settings from disabled plugins - filter them out here
   scope :live_descendants, lambda { where(:category => self.descendants.map(&:to_s)) unless Rails.env.development? }
-
-  scoped_search :on => :name, :complete_value => :true
-  scoped_search :on => :description, :complete_value => :true
 
   def self.per_page; 20 end # can't use our own settings
 

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -4,6 +4,7 @@ class SmartProxy < ActiveRecord::Base
   friendly_id :name
   include Taxonomix
   include Parameterizable::ByIdName
+  include SearchScope::SmartProxy
   audited :allow_mass_assignment => true
 
   attr_accessible :name, :url, :location_ids, :organization_ids
@@ -26,10 +27,6 @@ class SmartProxy < ActiveRecord::Base
 
   # There should be no problem with associating features before the proxy is saved as the whole operation is in a transaction
   before_save :sanitize_url, :associate_features
-
-  scoped_search :on => :name, :complete_value => :true
-  scoped_search :on => :url, :complete_value => :true
-  scoped_search :in => :features, :on => :name, :rename => :feature, :complete_value => :true
 
   # with proc support, default_scope can no longer be chained
   # include all default scoping here

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -9,6 +9,7 @@ class Subnet < ActiveRecord::Base
   include Taxonomix
   include Parameterizable::ByIdName
   include EncOutput
+  include SearchScope::Subnet
   audited :allow_mass_assignment => true
 
   validates_lengths_from_database :except => [:gateway]
@@ -45,11 +46,6 @@ class Subnet < ActiveRecord::Base
       order('vlanid')
     end
   }
-
-  scoped_search :on => [:name, :network, :mask, :gateway, :dns_primary, :dns_secondary,
-                        :vlanid, :ipam, :boot_mode], :complete_value => true
-
-  scoped_search :in => :domains, :on => :name, :rename => :domain, :complete_value => true
 
   class Jail < ::Safemode::Jail
     allow :name, :network, :mask, :cidr, :title, :to_label, :gateway, :dns_primary, :dns_secondary,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
   include Foreman::ThreadSession::UserModel
   include Taxonomix
   include DirtyAssociations
+  include SearchScope::User
   audited :except => [:last_login_on, :password, :password_hash, :password_salt, :password_confirmation], :allow_mass_assignment => true
   self.auditing_enabled = !Foreman.in_rake?('db:migrate')
 
@@ -91,16 +92,6 @@ class User < ActiveRecord::Base
 
   after_create :welcome_mail
 
-  scoped_search :on => :login, :complete_value => :true
-  scoped_search :on => :firstname, :complete_value => :true
-  scoped_search :on => :lastname, :complete_value => :true
-  scoped_search :on => :mail, :complete_value => :true
-  scoped_search :on => :admin, :complete_value => { :true => true, :false => false }, :ext_method => :search_by_admin
-  scoped_search :on => :last_login_on, :complete_value => :true, :only_explicit => true
-  scoped_search :in => :roles, :on => :name, :rename => :role, :complete_value => true
-  scoped_search :in => :roles, :on => :id, :rename => :role_id
-  scoped_search :in => :cached_usergroups, :on => :name, :rename => :usergroup, :complete_value => true
-
   default_scope lambda {
     with_taxonomy_scope do
       order('firstname')
@@ -116,20 +107,6 @@ class User < ActiveRecord::Base
       @authorizer ||= Authorizer.new(self)
       @authorizer.can?(permission, subject)
     end
-  end
-
-  def self.search_by_admin(key, operator, value)
-    value      = value == 'true'
-    value      = !value if operator == '<>'
-    conditions = [self.table_name, Usergroup.table_name].map do |base|
-      "(#{base}.admin = ?" + (value ? ')' : " OR #{base}.admin IS NULL)")
-    end
-    conditions = conditions.join(value ? ' OR ' : ' AND ')
-
-    {
-      :include    => :cached_usergroups,
-      :conditions => sanitize_sql_for_conditions([conditions, value, value])
-    }
   end
 
   # note that if you assign user new usergroups which change the admin flag you must save


### PR DESCRIPTION
Scoped search definitions can be cumbersome at times and don't really
define the business logic of a model. I think hiding them under the
carpet by moving most of the definitions to concerns (as we do with
    hostext) we can later on include would keep the code cleaner.

There are 3 or 4 models with just 1 scoped_search attribute I didn't
bother to move. Later commits that move them into concerns when they
become bigger can just reference this issue.
