### PR TITLE
fixing jenkins.rake task to load rails only once

### DIFF
--- a/lib/tasks/jenkins.rake
+++ b/lib/tasks/jenkins.rake
@@ -3,8 +3,6 @@ begin
 
   namespace :jenkins do
     task :unit do
-      Rails.env = 'test'
-      Rake::Task['db:migrate'].invoke
       system "rake jenkins:setup:minitest test RAILS_ENV=test"
       exit($?.exitstatus)
     end


### PR DESCRIPTION
The current task runs db:migrate which loads the project into memory. Removing that only loads the project once, and since the CI runs db:migrate before tests, this should take less memory to run the CI task.
