### PR TITLE
Fixes #11618 - Replace validation tests by shoulda-matchers

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -36,7 +36,7 @@ class AuthSourceLdap < AuthSource
   validates :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :presence => true, :if => Proc.new { |auth| auth.onthefly_register? }
   validates :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :length => {:maximum => 30}, :allow_nil => true
   validates :account_password, :length => {:maximum => 60}, :allow_nil => true
-  validates :port, :presence => true, :numericality => {:only_integer => true}
+  validates :port, :presence => true
   validates :server_type, :presence => true, :inclusion => { :in => SERVER_TYPES.keys.map(&:to_s) }
   validate :validate_ldap_filter, :unless => Proc.new { |auth| auth.ldap_filter.blank? }
 

--- a/app/models/config_group_class.rb
+++ b/app/models/config_group_class.rb
@@ -11,5 +11,5 @@ class ConfigGroupClass < ActiveRecord::Base
 
   validates :puppetclass, :presence => true
   validates :config_group, :presence => true,
-                              :uniqueness => {:scope => :puppetclass}
+    :uniqueness => { :scope => :puppetclass_id }
 end

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -15,4 +15,6 @@ group :test do
   gem "poltergeist"
   gem 'test-unit' if RUBY_VERSION >= '2.2'
   gem 'test_after_commit', '~> 0.4'
+  gem 'shoulda-matchers', '2.8.0'
+  gem 'shoulda-context', '~> 1.2'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,8 +44,8 @@ Foreman::Application.configure do
   # Raise exception on mass assignment protection for Active Record models
   config.active_record.mass_assignment_sanitizer = :strict
 
-  #enables a few aliases - context, should, and should_eventually methods
-  config.minitest_spec_rails.mini_shoulda = true
+  # Enables a few aliases - context, should, and should_eventually methods
+  config.minitest_spec_rails.mini_shoulda = false
 
   # Use separate cache stores for parallel_tests
   config.cache_store = :file_store, Rails.root.join("tmp", "cache", "paralleltests#{ENV['TEST_ENV_NUMBER']}")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -96,7 +96,8 @@ Spork.prefork do
     alias_method :assert_include,     :assert_includes
     alias_method :assert_not_include, :assert_not_includes
     class <<self
-      alias_method :test,  :it
+      alias_method :test, :it
+      alias_method :context, :describe
     end
 
     # Add more helper methods to be used by all tests here...

--- a/test/unit/architecture_test.rb
+++ b/test/unit/architecture_test.rb
@@ -9,26 +9,11 @@ class ArchitectureTest < ActiveSupport::TestCase
     end
   end
 
-  test "should not save without a name" do
-    architecture = Architecture.new
-    assert_not architecture.save
-  end
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name)
+  should_not allow_value('  ').for(:name)
 
-  test "name should not be blank" do
-    architecture = Architecture.new :name => "   "
-    assert_empty architecture.name.strip
-    assert_not architecture.save
-  end
-
-  test "name should be unique" do
-    architecture = Architecture.new :name => "i386"
-    assert architecture.save
-
-    other_architecture = Architecture.new :name => "i386"
-    assert_not other_architecture.save
-  end
-
-  test "to_s retrives name" do
+  test "to_s retrieves name" do
     architecture = Architecture.new :name => "i386"
     assert architecture.to_s == architecture.name
   end

--- a/test/unit/auth_source_test.rb
+++ b/test/unit/auth_source_test.rb
@@ -5,22 +5,9 @@ class AuthSourceTest < ActiveSupport::TestCase
     @auth_source = AuthSource.new
   end
 
-  test "should not save without a name" do
-    assert !@auth_source.save
-  end
-
-  test "name should be unique" do
-    @auth_source.name = "connection"
-    @auth_source.save
-
-    other_auth_source = AuthSource.create :name => "connection"
-    assert !other_auth_source.save
-  end
-
-  test "name should not exceed 60 characters" do
-    @auth_source.name = "a" * 61
-    assert !@auth_source.save
-  end
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name)
+  should validate_length_of(:name).is_at_most(60)
 
   test "when auth_method_name is applied should return 'Abstract'" do
     @auth_source.name = "connection"

--- a/test/unit/auth_sources/auth_source_ldap_test.rb
+++ b/test/unit/auth_sources/auth_source_ldap_test.rb
@@ -7,119 +7,29 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
     User.current = users(:admin)
   end
 
-  test "should exists a name" do
-    missing(:name)
-    refute @auth_source_ldap.save
-
-    set(:name)
-    assert @auth_source_ldap.save
-  end
-
-  test "should exists a host" do
-    missing(:host)
-    refute @auth_source_ldap.save
-
-    set(:host)
-    assert @auth_source_ldap.save
-  end
-
-  test "should exists a attr_login" do
-    missing(:attr_login)
-    @auth_source_ldap.onthefly_register = true
-    refute @auth_source_ldap.save
-
-    set(:attr_login)
-    set(:attr_firstname)
-    set(:attr_lastname)
-    set(:attr_mail)
-    @auth_source_ldap.onthefly_register = true
-    assert @auth_source_ldap.save
-  end
+  should validate_presence_of(:name)
+  should validate_presence_of(:host)
+  should validate_presence_of(:server_type)
+  should validate_presence_of(:port)
+  should_not validate_presence_of(:ldap_filter)
+  should_not allow_value('(').for(:ldap_filter)
+  should allow_value('').for(:ldap_filter)
+  should allow_value('    ').for(:ldap_filter)
+  should allow_value('key=value').for(:ldap_filter)
+  should validate_length_of(:name).is_at_most(60)
+  should validate_length_of(:host).is_at_most(60)
+  should validate_length_of(:account_password).is_at_most(60)
+  should validate_length_of(:account).is_at_most(255)
+  should validate_length_of(:base_dn).is_at_most(255)
+  should validate_length_of(:ldap_filter).is_at_most(255)
+  should validate_length_of(:attr_login).is_at_most(30)
+  should validate_length_of(:attr_firstname).is_at_most(30)
+  should validate_length_of(:attr_lastname).is_at_most(30)
+  should validate_length_of(:attr_mail).is_at_most(30)
 
   test "after initialize if port == 0 should automatically change to 389" do
     other_auth_source_ldap = AuthSourceLdap.new
     assert_equal 389, other_auth_source_ldap.port
-  end
-
-  test "the name should not exceed the 60 characters" do
-    missing(:name)
-    assigns_a_string_of_length_greater_than(60, :name=)
-    refute @auth_source_ldap.save
-  end
-
-  test "the host should not exceed the 60 characters" do
-    missing(:host)
-    assigns_a_string_of_length_greater_than(60, :host=)
-    refute @auth_source_ldap.save
-  end
-
-  test "the account_password should not exceed the 60 characters" do
-    assigns_a_string_of_length_greater_than(60, :account_password=)
-    refute @auth_source_ldap.save
-  end
-
-  test "the account should not exceed the 255 characters" do
-    assigns_a_string_of_length_greater_than(255, :account=)
-    refute @auth_source_ldap.save
-  end
-
-  test "the base_dn should not exceed the 255 characters" do
-    assigns_a_string_of_length_greater_than(255, :base_dn=)
-    refute @auth_source_ldap.save
-  end
-
-  test "the ldap_filter should not exceed the 255 characters" do
-    assigns_a_string_of_length_greater_than(255, :ldap_filter=)
-    refute @auth_source_ldap.save
-  end
-
-  test "the attr_login should not exceed the 30 characters" do
-    missing(:attr_login)
-    assigns_a_string_of_length_greater_than(30, :attr_login=)
-    refute @auth_source_ldap.save
-  end
-
-  test "the attr_firstname should not exceed the 30 characters" do
-    assigns_a_string_of_length_greater_than(30, :attr_firstname=)
-    refute @auth_source_ldap.save
-  end
-
-  test "the attr_lastname should not exceed the 30 characters" do
-    assigns_a_string_of_length_greater_than(30, :attr_lastname=)
-    refute @auth_source_ldap.save
-  end
-
-  test "the attr_mail should not exceed the 30 characters" do
-    assigns_a_string_of_length_greater_than(30, :attr_mail=)
-    refute @auth_source_ldap.save
-  end
-
-  test "port should be a integer" do
-    missing(:port)
-    @auth_source_ldap.port = "crap"
-    refute @auth_source_ldap.save
-
-    @auth_source_ldap.port = 123
-    assert @auth_source_ldap.save
-  end
-
-  test "invalid ldap_filter fails validation" do
-    @auth_source_ldap.ldap_filter = "("
-    refute @auth_source_ldap.valid?
-  end
-
-  test "valid ldap_filter passes validation" do
-    missing(:ldap_filter)
-    assert @auth_source_ldap.valid?
-
-    @auth_source_ldap.ldap_filter = ""
-    assert @auth_source_ldap.valid?
-
-    @auth_source_ldap.ldap_filter = "   "
-    assert @auth_source_ldap.valid?
-
-    @auth_source_ldap.ldap_filter = "key=value"
-    assert @auth_source_ldap.valid?
   end
 
   test "should strip the ldap attributes before validate" do
@@ -317,17 +227,5 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
     end
     LdapFluff.any_instance.stubs(:valid_user?).returns(true)
     LdapFluff.any_instance.stubs(:find_user).returns([entry])
-  end
-
-  def missing(attr)
-    @auth_source_ldap.send("#{attr}=", nil)
-  end
-
-  def set(attr)
-    @auth_source_ldap.send("#{attr}=", FactoryGirl.attributes_for(:auth_source_ldap)[attr])
-  end
-
-  def assigns_a_string_of_length_greater_than(length, method)
-    @auth_source_ldap.send method, "this is010this is020this is030this is040this is050this is060this is070this is080this is090this is100this is110this is120this is130this is140this is150this is160this is170this is180this is190this is200this is210this is220this is230this is240this is250 and something else"
   end
 end

--- a/test/unit/cached_user_role_test.rb
+++ b/test/unit/cached_user_role_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class CachedUserRoleTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/unit/cached_usergroup_member_test.rb
+++ b/test/unit/cached_usergroup_member_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class CachedUsergroupMemberTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/unit/common_parameter_test.rb
+++ b/test/unit/common_parameter_test.rb
@@ -1,46 +1,10 @@
 require 'test_helper'
 
 class CommonParameterTest < ActiveSupport::TestCase
-  setup do
-    User.current = users :admin
-  end
-  test "name can't be blank" do
-    parameter = CommonParameter.new :name => "  ", :value => "some_value"
-    assert parameter.name.strip.empty?
-    assert !parameter.save
-  end
-
-  test "name can't contain white spaces" do
-    parameter = CommonParameter.new :name => "   a new     param    ", :value => "some_value"
-    assert !parameter.save
-
-    parameter.name.gsub!(/\s+/,'_')
-    assert parameter.save
-  end
-
-  test "value can be blank" do
-    parameter = CommonParameter.new :name => "some_parameter", :value => "   "
-    assert parameter.value.strip.empty?
-    assert parameter.save
-  end
-
-  test "value can be empty" do
-    parameter = CommonParameter.new :name => "some_parameter", :value => ""
-    assert parameter.value.strip.empty?
-    assert parameter.save
-  end
-
-  test "value can contain spaces and unusual characters" do
-    parameter = CommonParameter.new :name => "some_parameter", :value => "   some crazy \"\'&<*%# value"
-    assert parameter.save
-
-    assert_equal parameter.value, "some crazy \"\'&<*%# value"
-  end
-
-  test "duplicate names cannot exist" do
-    CommonParameter.create :name => "some_parameter", :value => "value"
-    parameter2 = CommonParameter.create :name => "some_parameter", :value => "value"
-    assert !parameter2.valid?
-    assert  parameter2.errors.full_messages[0] == "Name has already been taken"
-  end
+  should validate_presence_of(:name)
+  should_not validate_presence_of(:value)
+  should validate_uniqueness_of(:name)
+  should_not allow_value('   a new param').for(:name)
+  should allow_value('   ').for(:value)
+  should allow_value('   some crazy \"\'&<*%# value').for(:value)
 end

--- a/test/unit/compute_attribute_test.rb
+++ b/test/unit/compute_attribute_test.rb
@@ -13,15 +13,10 @@ class ComputeAttributeTest < ActiveSupport::TestCase
     Fog.unmock!
   end
 
-  test "save if unique" do
-    set = ComputeAttribute.new :compute_resource_id => @compute_resource.id, :compute_profile_id => compute_profiles(:three).id
-    assert set.save
-  end
-
-  test "do not save if not unique" do
-    set = ComputeAttribute.new :compute_resource_id => @compute_resource.id, :compute_profile_id => @compute_profile.id
-    assert !set.save
-  end
+  should validate_uniqueness_of(:compute_profile_id).
+    scoped_to(:compute_resource_id)
+  should validate_uniqueness_of(:compute_resource_id).
+    scoped_to(:compute_profile_id)
 
   test "getter attributes in vm_attrs hash" do
     assert_equal 'm1.small', @set.flavor_id

--- a/test/unit/compute_profile_test.rb
+++ b/test/unit/compute_profile_test.rb
@@ -5,15 +5,9 @@ class ComputeProfileTest < ActiveSupport::TestCase
     User.current = users :admin
   end
 
-  test "name can't be blank" do
-    cp = ComputeProfile.new :name => "   "
-    assert !cp.save
-  end
-
-  test "name must be unique" do
-    cp = ComputeProfile.new :name => "1-Small"
-    assert !cp.save
-  end
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name)
+  should_not allow_value('   ').for(:name)
 
   test "should not destroy if in use by hostgroup" do
     #hostgroups(:common) uses compute_profiles(:one)

--- a/test/unit/config_group_class_test.rb
+++ b/test/unit/config_group_class_test.rb
@@ -1,10 +1,7 @@
 require 'test_helper'
 
 class ConfigGroupClassTest < ActiveSupport::TestCase
-  test "combination of config_group and puppetclass must be unique" do
-    puppetclass = puppetclasses(:five)
-    config_group = config_groups(:one)
-    refute ConfigGroupClass.new(:puppetclass_id => puppetclass.id,
-                                :config_group_id => config_group.id).valid?
-  end
+  should validate_presence_of(:config_group)
+  should validate_presence_of(:puppetclass)
+  should validate_uniqueness_of(:config_group).scoped_to(:puppetclass_id)
 end

--- a/test/unit/config_group_test.rb
+++ b/test/unit/config_group_test.rb
@@ -1,11 +1,6 @@
 require 'test_helper'
 
 class ConfigGroupTest < ActiveSupport::TestCase
-  test "name can't be blank" do
-    refute ConfigGroup.new.valid?
-  end
-
-  test "name is unique" do
-    refute ConfigGroup.new(:name => 'Monitoring').valid?
-  end
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name)
 end

--- a/test/unit/domain_parameter_test.rb
+++ b/test/unit/domain_parameter_test.rb
@@ -1,29 +1,8 @@
 require 'test_helper'
 
 class DomainParameterTest < ActiveSupport::TestCase
-  test "should have a reference_id" do
-    parameter = DomainParameter.create(:name => "value", :value => "value")
-    assert !parameter.save
-
-    setup_user "create"
-    domain = Domain.where(:name => "domain").first_or_create
-    parameter.reference_id = domain.id
-    assert parameter.save
-  end
-
-  test "duplicate names cannot exist in a domain" do
-    setup_user "create"
-    DomainParameter.create :name => "some_parameter", :value => "value", :reference_id => Domain.first.id
-    parameter2 = DomainParameter.create :name => "some_parameter", :value => "value", :reference_id => Domain.first.id
-    refute parameter2.valid?
-    assert_equal parameter2.errors.full_messages[0], "Name has already been taken"
-  end
-
-  test "duplicate names can exist in different domains" do
-    setup_user "create"
-    DomainParameter.create :name => "some_parameter", :value => "value", :reference_id => Domain.first.id
-    parameter2 = DomainParameter.create :name => "some_parameter", :value => "value", :reference_id => Domain.last.id
-    assert parameter2.valid?
-  end
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name).scoped_to(:reference_id)
+  should belong_to(:domain).with_foreign_key(:reference_id)
 end
 

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -11,22 +11,9 @@ class DomainTest < ActiveSupport::TestCase
     end
   end
 
-  test "should not save without a name" do
-    assert !@new_domain.save
-  end
-
-  test "should exists a unique name" do
-    other_domain = Domain.new(:name => "mydomain.net")
-    assert !other_domain.save
-  end
-
-  test "should exists a unique fullname" do
-    @domain.fullname = "full_name"
-    @domain.save
-
-    other_domain = Domain.new(:name => "otherDomain", :fullname => "full_name")
-    assert !other_domain.save
-  end
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name)
+  should validate_uniqueness_of(:fullname)
 
   test "when cast to string should return the name" do
     s = @domain.to_s

--- a/test/unit/environment_test.rb
+++ b/test/unit/environment_test.rb
@@ -9,16 +9,11 @@ class EnvironmentTest < ActiveSupport::TestCase
   end
 
   test "should have name" do
-    env = Environment.new
-    refute env.valid?
+    assert validate_presence_of(:name)
   end
 
   test "name should be unique" do
-    as_admin do
-      env = Environment.create :name => "foo"
-      env2 = Environment.new :name => env.name
-      refute env2.valid?
-    end
+    assert validate_uniqueness_of(:name)
   end
 
   test "to_label should print name" do

--- a/test/unit/feature_test.rb
+++ b/test/unit/feature_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class FeatureTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
+  should have_and_belong_to_many(:smart_proxies)
+  should validate_presence_of(:name)
 end

--- a/test/unit/group_parameter_test.rb
+++ b/test/unit/group_parameter_test.rb
@@ -1,31 +1,8 @@
 require 'test_helper'
 
 class GroupParameterTest < ActiveSupport::TestCase
-  setup do
-    User.current = users :admin
-  end
-  test "should have a reference_id" do
-    group_parameter = GroupParameter.new
-    assert !group_parameter.save
-
-    group_parameter.name = "valid"
-    group_parameter.value = "valid"
-    hostgroup = Hostgroup.where(:name => "valid").first_or_create
-    group_parameter.reference_id = hostgroup.id
-    assert group_parameter.save
-  end
-
-  test "duplicate names cannot exist in a hostgroup" do
-    GroupParameter.create :name => "some_parameter", :value => "value", :reference_id => hostgroups(:common).id
-    parameter2 = GroupParameter.create :name => "some_parameter", :value => "value", :reference_id => hostgroups(:common).id
-    assert !parameter2.valid?
-    assert  parameter2.errors.full_messages[0] == "Name has already been taken"
-  end
-
-  test "duplicate names can exist in different hostgroups" do
-    GroupParameter.create :name => "some_parameter", :value => "value", :reference_id => hostgroups(:common).id
-    parameter2 = GroupParameter.create :name => "some_parameter", :value => "value", :reference_id => hostgroups(:db).id
-    assert parameter2.valid?
-  end
+  should validate_presence_of(:reference_id)
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name).scope(:reference_id)
 end
 

--- a/test/unit/host_parameter_test.rb
+++ b/test/unit/host_parameter_test.rb
@@ -1,37 +1,7 @@
 require 'test_helper'
 
 class HostParameterTest < ActiveSupport::TestCase
-  setup do
-    User.current = users :admin
-  end
-  test "should have a reference_id" do
-    host_parameter = HostParameter.new
-    host_parameter.name = "valid"
-    host_parameter.value = "valid"
-    assert !host_parameter.save
-
-    host = FactoryGirl.create(:host)
-    host_parameter.reference_id = host.id
-    assert host_parameter.save
-  end
-
-  test "duplicate names cannot exist for a host" do
-    @host = FactoryGirl.create(:host)
-    as_admin do
-      @parameter1 = HostParameter.create :name => "some_parameter", :value => "value", :reference_id => @host.id
-      @parameter2 = HostParameter.create :name => "some_parameter", :value => "value", :reference_id => @host.id
-    end
-    assert !@parameter2.valid?
-    assert  @parameter2.errors.full_messages[0] == "Name has already been taken"
-  end
-
-  test "duplicate names can exist for different hosts" do
-    @host1 = FactoryGirl.create(:host)
-    @host2 = FactoryGirl.create(:host)
-    as_admin do
-      @parameter1 = HostParameter.create! :name => "some_parameter", :value => "value", :reference_id => @host1.id
-      @parameter2 = HostParameter.create! :name => "some_parameter", :value => "value", :reference_id => @host2.id
-    end
-    assert @parameter2.valid?
-  end
+  should validate_presence_of(:reference_id)
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name).scope(:reference_id)
 end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -8,11 +8,7 @@ class HostTest < ActiveSupport::TestCase
     Foreman::Model::EC2.any_instance.stubs(:image_exists?).returns(true)
   end
 
-  test "should not save without a hostname" do
-    host = Host.new
-    host.valid?
-    assert host.errors[:name].include?("can't be blank")
-  end
+  should validate_presence_of(:name)
 
   test "should not save with invalid hostname" do
     host = Host.new :name => "invalid_hostname"

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -5,9 +5,7 @@ class HostgroupTest < ActiveSupport::TestCase
     User.current = users :admin
   end
   test "name can't be blank" do
-    host_group = Hostgroup.new :name => "  "
-    assert host_group.name.strip.empty?
-    assert !host_group.save
+    assert validate_presence_of(:name)
   end
 
   test "name strips leading and trailing white spaces" do
@@ -18,11 +16,7 @@ class HostgroupTest < ActiveSupport::TestCase
   end
 
   test "name must be unique" do
-    host_group = Hostgroup.new :name => "some hosts"
-    assert host_group.save
-
-    other_host_group = Hostgroup.new :name => "some hosts"
-    assert !other_host_group.save
+    assert validate_uniqueness_of(:name)
   end
 
   def setup_user(operation)

--- a/test/unit/location_parameter_test.rb
+++ b/test/unit/location_parameter_test.rb
@@ -1,33 +1,7 @@
 require 'test_helper'
 
 class LocationParameterTest < ActiveSupport::TestCase
-  setup do
-    User.current = users :admin
-  end
-
-  test 'should have a reference_id' do
-    location_parameter       = LocationParameter.new
-    location_parameter.name  = 'valid'
-    location_parameter.value = 'valid'
-    assert_not location_parameter.save
-
-    location                        = Location.first
-    location_parameter.reference_id = location.id
-    assert location_parameter.save
-  end
-
-  test 'duplicate names cannot exist for a location' do
-    location = taxonomies(:location1)
-    LocationParameter.create! :name => 'some_parameter', :value => 'value', :reference_id => location.id
-    parameter2 = LocationParameter.create :name => 'some_parameter', :value => 'value', :reference_id => location.id
-    refute parameter2.valid?
-    assert_equal ['has already been taken'], parameter2.errors[:name]
-  end
-
-  test 'duplicate names can exist for different taxonomies' do
-    location1 = taxonomies(:location1)
-    location2 = taxonomies(:location2)
-    assert LocationParameter.create! :name => 'some_parameter', :value => 'value', :reference_id => location1.id
-    assert LocationParameter.create! :name => 'some_parameter', :value => 'value', :reference_id => location2.id
-  end
+  should validate_presence_of(:reference_id)
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name).scope(:reference_id)
 end

--- a/test/unit/organization_parameter_test.rb
+++ b/test/unit/organization_parameter_test.rb
@@ -1,33 +1,7 @@
 require 'test_helper'
 
 class OrganizationParameterTest < ActiveSupport::TestCase
-  setup do
-    User.current = users :admin
-  end
-
-  test 'should have a reference_id' do
-    organization_parameter       = OrganizationParameter.new
-    organization_parameter.name  = 'valid'
-    organization_parameter.value = 'valid'
-    assert_not organization_parameter.save
-
-    organization                        = Organization.first
-    organization_parameter.reference_id = organization.id
-    assert organization_parameter.save
-  end
-
-  test 'duplicate names cannot exist for a organization' do
-    organization = taxonomies(:organization1)
-    OrganizationParameter.create! :name => 'some_parameter', :value => 'value', :reference_id => organization.id
-    parameter2 = OrganizationParameter.create :name => 'some_parameter', :value => 'value', :reference_id => organization.id
-    assert_not parameter2.valid?
-    assert_equal ['has already been taken'], parameter2.errors[:name]
-  end
-
-  test 'duplicate names can exist for different taxonomies' do
-    organization1 = taxonomies(:organization1)
-    organization2 = taxonomies(:organization2)
-    assert OrganizationParameter.create! :name => 'some_parameter', :value => 'value', :reference_id => organization1.id
-    assert OrganizationParameter.create! :name => 'some_parameter', :value => 'value', :reference_id => organization2.id
-  end
+  should validate_presence_of(:reference_id)
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name).scope(:reference_id)
 end

--- a/test/unit/os_default_template_test.rb
+++ b/test/unit/os_default_template_test.rb
@@ -1,8 +1,10 @@
 require 'test_helper'
 
 class OsDefaultTemplateTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
+  should belong_to(:provisioning_template)
+  should belong_to(:operatingsystem)
+  should belong_to(:template_kind)
+  should validate_presence_of(:provisioning_template_id)
+  should validate_presence_of(:template_kind_id)
+  should validate_uniqueness_of(:template_kind_id).scoped_to(:operatingsystem_id)
 end

--- a/test/unit/ptable_test.rb
+++ b/test/unit/ptable_test.rb
@@ -5,11 +5,10 @@ class PtableTest < ActiveSupport::TestCase
     User.current = users :admin
   end
 
-  test "name can't be blank" do
-    partition_table = Ptable.new :name => "   ", :layout => "any layout"
-    assert partition_table.name.strip.empty?
-    assert !partition_table.save
-  end
+  should validate_presence_of(:name)
+  should_not allow_value('  ').for(:name)
+  should validate_uniqueness_of(:name)
+  should validate_presence_of(:layout)
 
   test "name strips leading and trailing white spaces" do
     partition_table = Ptable.new :name => "   Archlinux        default  ", :layout => "any layout"
@@ -17,12 +16,6 @@ class PtableTest < ActiveSupport::TestCase
 
     refute partition_table.name.ends_with?(' ')
     refute partition_table.name.starts_with?(' ')
-  end
-
-  test "layout can't be blank" do
-    partition_table = Ptable.new :name => "Archlinux default", :layout => "   "
-    assert partition_table.layout.strip.empty?
-    assert !partition_table.save
   end
 
   test "os family can be one of defined os families" do
@@ -60,14 +53,6 @@ class PtableTest < ActiveSupport::TestCase
   #    partition_table.layout.strip!.squeeze!(" ")
   #    assert partition_table.save
   #  end
-
-  test "name must be unique" do
-    partition_table_one = Ptable.new :name => "Archlinux default", :layout => "some layout"
-    assert partition_table_one.save
-
-    partition_table_two = Ptable.new :name => "Archlinux default", :layout => "some other layout"
-    assert !partition_table_two.save
-  end
 
   test "should not destroy while using" do
     partition_table = Ptable.new :name => "Ubuntu default", :layout => "some layout"

--- a/test/unit/puppetclass_test.rb
+++ b/test/unit/puppetclass_test.rb
@@ -5,24 +5,14 @@ class PuppetclassTest < ActiveSupport::TestCase
     User.current = users :admin
   end
 
-  test "name can't be blank" do
-    puppet_class = Puppetclass.new
-    assert !puppet_class.save
-  end
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name)
 
   test "name strips leading and trailing white spaces" do
     puppet_class = Puppetclass.new :name => "   testclass   "
     assert puppet_class.save
     refute puppet_class.name.ends_with?(' ')
     refute puppet_class.name.starts_with?(' ')
-  end
-
-  test "name must be unique" do
-    puppet_class = Puppetclass.new :name => "testclass"
-    assert puppet_class.save
-
-    other_puppet_class = Puppetclass.new :name => "testclass"
-    assert !other_puppet_class.save
   end
 
   test "looking for a nonexistent host returns no puppetclasses" do

--- a/test/unit/realm_test.rb
+++ b/test/unit/realm_test.rb
@@ -7,43 +7,24 @@ class RealmTest < ActiveSupport::TestCase
     @realm = realms(:myrealm)
   end
 
-  test "should not save without a name" do
-    assert !@new_realm.save
-  end
-
-  test "should exists a unique name" do
-    other_realm = Realm.new(:name => "myrealm.net")
-    assert !other_realm.save
-  end
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name)
+  should have_many(:locations).
+    source(:taxonomy).
+    conditions("taxonomies.type=Location").
+    through('taxable_taxonomies')
 
   test "when cast to string should return the name" do
-    s = @realm.to_s
-    assert_equal @realm.name, s
+    assert_equal @realm.name, @realm.to_s
   end
 
   test "should not destroy if it contains hosts" do
     disable_orchestration
     host = FactoryGirl.create(:host, :realm => @realm)
-
     assert host.save
-
     realm = host.realm
     assert !realm.destroy
     assert_match /is used by/, realm.errors.full_messages.join("\n")
-  end
-
-  test "realm can be assigned to locations" do
-    location1 = Location.create :name => "Zurich"
-    assert location1.save!
-
-    location2 = Location.create :name => "Switzerland"
-    assert location2.save!
-
-    realm = Realm.create :name => "test.net", :realm_proxy => smart_proxies(:realm), :realm_type => "FreeIPA"
-    realm.locations.destroy_all
-    realm.locations.push location1
-    realm.locations.push location2
-    assert realm.save!
   end
 
   # test taxonomix methods

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -19,38 +19,12 @@
 require "test_helper"
 
 class RoleTest < ActiveSupport::TestCase
-  it "should respond_to user_roles" do
-    role = roles(:manager)
-    role.must_respond_to :user_roles
-    role.must_respond_to :users
-  end
-
-  it "should have unique name" do
-    # Manager is in role fixtures
-    Role.new(:name => "Manager").wont_be :valid?
-    role = Role.new(:name => "Supervisor")
-    role.must_be :valid?
-  end
-
-  it "should not be valid without a name" do
-    role = Role.new(:name => "")
-    role.wont_be :valid?
-  end
-
-  it "should allow value 'a role name' for name" do
-    role = Role.new(:name => "a role name")
-    role.must_be :valid?
-  end
-
-  it "should allow utf characters in name" do
-    role = Role.new(:name => "トメル３４；。")
-    role.must_be :valid?
-  end
-
-  it "should allow email address in name" do
-    role = Role.new(:name => "test@example.com")
-    role.must_be :valid?
-  end
+  should have_many(:user_roles)
+  should validate_presence_of(:name)
+  should validate_uniqueness_of(:name)
+  should allow_value('a role name').for(:name)
+  should allow_value('トメル３４；。').for(:name)
+  should allow_value('test@example.com').for(:name)
 
   it "should strip leading space on name" do
     role = Role.new(:name => " a role name")

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -48,12 +48,13 @@ class SettingTest < ActiveSupport::TestCase
     assert_equal 3, setting.value
   end
 
-  def test_default_value_can_be_nil
-    assert Setting.create(:name => "foo", :default => nil, :description => "test foo")
-    assert_equal nil, Setting["foo"]
-  end
+  should validate_presence_of(:name)
+  should validate_presence_of(:default)
+  should validate_uniqueness_of(:name)
+  should validate_inclusion_of(:settings_type).in(Setting::TYPES)
+  should allow_value(nil).for(:default)
 
-  def test_should_return_updated_value_only_after_it_gets_presistent
+  def test_should_return_updated_value_only_after_it_is saved
     setting = Setting.create(:name => "foo", :value => 5, :default => 5, :description => "test foo")
 
     setting.value = 3
@@ -87,11 +88,6 @@ class SettingTest < ActiveSupport::TestCase
     Setting.create!(:name => 'administrator', :description => 'Test', :default => 'root@localhost')
     s = Setting.find_by_name 'administrator'
     assert_equal 'Test', s.description
-  end
-
-  def test_create_with_missing_attrs_does_not_persist
-    setting = Setting.create(:name => "foo")
-    assert_equal false, setting.persisted?
   end
 
   def test_create_exclamation_with_missing_attrs_raises_exception

--- a/test/unit/source_test.rb
+++ b/test/unit/source_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-
-class SourceTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
-end

--- a/test/unit/taxable_taxonomy_test.rb
+++ b/test/unit/taxable_taxonomy_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-
-class TaxableTaxonomyTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
-end

--- a/test/unit/taxonomy_test.rb
+++ b/test/unit/taxonomy_test.rb
@@ -6,6 +6,8 @@ class TaxonomyTest < ActiveSupport::TestCase
     SETTINGS.stubs(:[]).with(:locations_enabled).returns(false)
   end
 
+  should validate_uniqueness_of(:name)
+
   test '.enabled?' do
     assert Taxonomy.enabled?(:organization)
     refute Taxonomy.enabled?(:location)
@@ -76,14 +78,6 @@ class TaxonomyTest < ActiveSupport::TestCase
     as_user(user) do
       assert_equal org1, Organization.expand(org1)
       assert_equal [org1, org2], Organization.expand([org1, org2])
-    end
-  end
-
-  test "name uniqueness" do
-    FactoryGirl.create(:organization, :name => "ACME")
-    # If there's a validation error the create method raises an exception
-    assert_nothing_raised do
-      FactoryGirl.create(:location, :name => "ACME")
     end
   end
 end

--- a/test/unit/template_kind_test.rb
+++ b/test/unit/template_kind_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-
-class TemplateKindTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
-end

--- a/test/unit/token_test.rb
+++ b/test/unit/token_test.rb
@@ -1,20 +1,9 @@
 require 'test_helper'
 
 class TokenTest < ActiveSupport::TestCase
-  test "a token has a value" do
-    t = Token.new
-    assert !t.save
-  end
-
-  test "a token has an expiry" do
-    t = Token.new :value => "aaaaaa"
-    assert !t.save
-  end
-
-  test "a token is assigned to a host" do
-    t = Token.new :value => "aaaaaa", :expires => Time.now
-    assert !t.save
-  end
+  should validate_presence_of(:value)
+  should validate_presence_of(:expires)
+  should validate_presence_of(:host)
 
   test "a token expires when set to expire" do
     expiry = Time.now

--- a/test/unit/usergroup_test.rb
+++ b/test/unit/usergroup_test.rb
@@ -10,15 +10,11 @@ class UsergroupTest < ActiveSupport::TestCase
   end
 
   test "name should be unique" do
-    one = FactoryGirl.create(:usergroup)
-    two = FactoryGirl.build(:usergroup, :name => one.name)
-
-    refute two.valid?
+    assert validate_uniqueness_of(:name)
   end
 
   test "name can't be blank" do
-    group = FactoryGirl.build(:usergroup, :name => "")
-    refute group.valid?
+    assert validate_presence_of(:name)
   end
 
   test "name is unique across user as well as usergroup" do
@@ -92,12 +88,8 @@ class UsergroupTest < ActiveSupport::TestCase
   end
 
   test "removes user join model records" do
-    ug1 = Usergroup.where(:name => "ug1").first_or_create
-    u1  = FactoryGirl.build(:user)
-    ug1.users = [u1]
-    assert_difference('UsergroupMember.count', -1) do
-      ug1.destroy
-    end
+    assert have_many(:usergroup_members).dependent(:destroy)
+    assert have_many(:users).dependent(:destroy)
   end
 
   test "removes all cached_user_roles when roles are disassociated" do


### PR DESCRIPTION
A good chunk of our unit tests are testing whether a validation is
working or not by testing it actively. For the validations we've
added ourselves I would say it's fine. However for validations that
 come from the Rails framework, we're essentially testing their job.

Instead of testing (for instance) validates(:name, :uniqueness =>
true) by creating two objects and verifying the second one won't
save (these tests are already done at the framework level), we
should simply test we're including validations in our models.

The well-maintained gem shoulda-matchers provide easy functions to
check we're including such validations, and other helpers we can
use to refactor our tests further and not test Rails functionality
twice.
